### PR TITLE
修复 popup 在暗色模式下，可能显示白色背景的问题

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "extension-manager",
-  "version": "0.5.17",
+  "version": "0.5.26",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "extension-manager",
-      "version": "0.5.17",
+      "version": "0.5.26",
       "license": "AGPL-3.0",
       "dependencies": {
         "@ant-design/icons": "^5.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "extension-manager",
-  "version": "0.5.25",
+  "version": "0.5.26",
   "description": "a chrome extension manager where you can add rules",
   "license": "AGPL-3.0",
   "repository": {

--- a/src/pages/Popup/index.jsx
+++ b/src/pages/Popup/index.jsx
@@ -70,6 +70,11 @@ prepare().then((props) => {
     </ConfigProvider>
   )
 
+  // 如果是 dark mode，则设置 body 的背景色为黑色
+  if (isDarkMode) {
+    document.body.style.backgroundColor = styled_dark_theme.bg
+  }
+
   fireEvent(props)
 })
 


### PR DESCRIPTION
原因：分组列表的菜单项太长，body 的背景色没有设置