### PR TITLE
fix: update Chrome Web Store URLs to new format

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -4,9 +4,9 @@
 
 [![release](https://img.shields.io/github/v/release/JasonGrass/auto-extension-manager?style=for-the-badge)](https://github.com/JasonGrass/auto-extension-manager/releases)
 
-[![chrome-web-store](https://img.shields.io/chrome-web-store/v/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
-[![users](https://img.shields.io/chrome-web-store/users/efajbgpnlnobnkgdcgcnclngeolnmggp.svg?style=for-the-badge)](https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
-[![stars](https://img.shields.io/chrome-web-store/stars/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
+[![chrome-web-store](https://img.shields.io/chrome-web-store/v/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
+[![users](https://img.shields.io/chrome-web-store/users/efajbgpnlnobnkgdcgcnclngeolnmggp.svg?style=for-the-badge)](https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
+[![stars](https://img.shields.io/chrome-web-store/stars/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
 
 [![edge-web-store](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=EDGE%20WEB%20STORE&color=ffba08&prefix=v&query=$.version&url=https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/pifijhmfdnkanlcnecpifkmjbfoopokf)](https://microsoftedge.microsoft.com/addons/detail/extension-manager/pifijhmfdnkanlcnecpifkmjbfoopokf)
 [![users](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=USERS&color=81bc06&query=$.activeInstallCount&url=https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/pifijhmfdnkanlcnecpifkmjbfoopokf)](https://microsoftedge.microsoft.com/addons/detail/extension-manager/pifijhmfdnkanlcnecpifkmjbfoopokf)
@@ -51,7 +51,7 @@ Bulk import extensions from shared text or json, simplifying the process of migr
 ## 🍉 Download
 
 Chrome Web Store
-<https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp>
+<https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp>
 
 Edge Web Store  
 <https://microsoftedge.microsoft.com/addons/detail/pifijhmfdnkanlcnecpifkmjbfoopokf>

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 [![release](https://img.shields.io/github/v/release/JasonGrass/auto-extension-manager?style=for-the-badge)](https://github.com/JasonGrass/auto-extension-manager/releases)
 
-[![chrome-web-store](https://img.shields.io/chrome-web-store/v/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
-[![users](https://img.shields.io/chrome-web-store/users/efajbgpnlnobnkgdcgcnclngeolnmggp.svg?style=for-the-badge)](https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
-[![stars](https://img.shields.io/chrome-web-store/stars/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
+[![chrome-web-store](https://img.shields.io/chrome-web-store/v/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
+[![users](https://img.shields.io/chrome-web-store/users/efajbgpnlnobnkgdcgcnclngeolnmggp.svg?style=for-the-badge)](https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
+[![stars](https://img.shields.io/chrome-web-store/stars/efajbgpnlnobnkgdcgcnclngeolnmggp?style=for-the-badge)](https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp)
 
 [![edge-web-store](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=EDGE%20WEB%20STORE&color=ffba08&prefix=v&query=$.version&url=https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/pifijhmfdnkanlcnecpifkmjbfoopokf)](https://microsoftedge.microsoft.com/addons/detail/extension-manager/pifijhmfdnkanlcnecpifkmjbfoopokf)
 [![users](https://img.shields.io/badge/dynamic/json?style=for-the-badge&label=USERS&color=81bc06&query=$.activeInstallCount&url=https://microsoftedge.microsoft.com/addons/getproductdetailsbycrxid/pifijhmfdnkanlcnecpifkmjbfoopokf)](https://microsoftedge.microsoft.com/addons/detail/extension-manager/pifijhmfdnkanlcnecpifkmjbfoopokf)
@@ -51,7 +51,7 @@ Extension Manager 是一个用于浏览器扩展管理的扩展。
 ## 🍉 下载
 
 Chrome 商店链接  
-<https://chrome.google.com/webstore/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp>
+<https://chromewebstore.google.com/detail/extension-manager/efajbgpnlnobnkgdcgcnclngeolnmggp>
 
 Edge 商店链接  
 <https://microsoftedge.microsoft.com/addons/detail/pifijhmfdnkanlcnecpifkmjbfoopokf>

--- a/src/pages/Options/management/import/helper/useReadyInstall.js
+++ b/src/pages/Options/management/import/helper/useReadyInstall.js
@@ -57,7 +57,7 @@ function buildInputs(inputs) {
   for (const item of items) {
     if (!item.webStoreUrl) {
       if (item.channel === "Chrome") {
-        item.webStoreUrl = `https://chrome.google.com/webstore/detail/${item.id}`
+        item.webStoreUrl = `https://chromewebstore.google.com/detail/${item.id}`
       } else if (item.channel === "Edge") {
         item.webStoreUrl = `https://microsoftedge.microsoft.com/addons/detail/${item.id}`
       }

--- a/src/pages/Options/management/utils/index.js
+++ b/src/pages/Options/management/utils/index.js
@@ -19,7 +19,7 @@ export function buildRecords(extensions, configs) {
 
     let storeUrl = ""
     if (extension.updateUrl?.includes(".google.com") || extension.channel === "Chrome") {
-      storeUrl = "https://chrome.google.com/webstore/detail/" + extension.id
+      storeUrl = "https://chromewebstore.google.com/detail/" + extension.id
     } else if (
       extension.updateUrl?.includes("edge.microsoft.com") ||
       extension.channel === "Edge"

--- a/src/utils/extensionHelper.js
+++ b/src/utils/extensionHelper.js
@@ -169,7 +169,7 @@ export const getHomepageUrl = (item, alwaysLinkToStore) => {
   }
 
   if (updateUrl.includes(".google.com")) {
-    return "https://chrome.google.com/webstore/detail/" + item.id
+    return "https://chromewebstore.google.com/detail/" + item.id
   } else if (updateUrl.includes("edge.microsoft.com")) {
     return "https://microsoftedge.microsoft.com/addons/detail/" + item.id
   } else {


### PR DESCRIPTION
Updates chrome.google.com/webstore to chromewebstore.google.com in:
- README.md
- README.en.md
- src/utils/extensionHelper.js
- src/pages/Options/management/utils/index.js
- src/pages/Options/management/import/helper/useReadyInstall.js
